### PR TITLE
Refactor: Error handling

### DIFF
--- a/.docs/error_handling.md
+++ b/.docs/error_handling.md
@@ -1,0 +1,46 @@
+# Error Handling
+Error handling is provided via a custom enum called `KohakuError` in [`error.rs`](../server/src/utils/error.rs) to wrap and map existing errors from other crates and construct custom errors while providing means to map these errors to meaningful HTTP status codes after the [`RFC 9110`]() definition:
+
+- `2XX` - Successful transaction
+- `4XX` - Client errors: User can fix by changing their request
+- `5XX` - Server errors: System issue that the user cannot fix
+
+Each response is in the structure of a JSON format, while errors feature the following structure:
+```json
+{
+  "status": HTTP_STATUS_CODE,
+  "kind": KOHAKU_ERROR_NAME,
+  "message": ERROR_MESSAGE,
+}
+```
+to provide meaningful ways to differentiate the response from the server.
+
+## Errors
+Errors can either happen during requests from a client or in internally defined processes like tasks, services or other core features.
+
+If an error occurs during a request, the error should be propagated to the response the client receives.
+While client errors should be probably exposed, server errors should hide the implementation for safety purposes.
+
+If the error occurs in a internally server-sided process, the error should be logged to make debugging more viable.
+
+### Error Types
+The following table shows what kind of errors are currently available on the server-side:
+
+| Name | Description | Status |
+| ---- | ----------- | ------ |
+| `BadRequest` | Given input is syntactically incorrect (e.g. results in a malformed JSON, wrong types) | `400` |
+| `ValidationError` | Given input is semantic incorrect and violates business logic (e.g. only positive numbers allowed but got -1 ) | `400` |
+| `Unauthorized` | Authorization failed, API key or token is invalid | `401` |
+| `Forbidden` | Missing permissions after successful authorization | `403` |
+| `NotFound` | Requested resource not found | `404` |
+| `RequestTimeout` | Response would be sent on an idle / inactive connection | `408` |
+| `Conflict` | Requested transaction violates any underlaying constraints that do not fall under `ValidationError`s business logic (e.g. unique constraint in database entry) | `409` |
+| `TooManyRequests` | Limit for requests in a timeframe reached | `429` |
+| 
+| `DatabaseConnectionError` | Database connection is either invalid, closed or failed; Wraps: [`diesel::r2d2::PoolError`](https://docs.diesel.rs/master/diesel/r2d2/type.PoolError.html) | `500` |
+| `DatabaseQueryError` | Database query failed to execute; Wraps: [`diesel::result::Error`](https://docs.diesel.rs/2.1.x/diesel/result/enum.Error.html) | `500`
+| `SchedulerError` | Initialization or task scheduling failed; Wraps: [`tokio_cron_scheduler::JobSchedulerError`](https://docs.rs/tokio-cron-scheduler/latest/tokio_cron_scheduler/enum.JobSchedulerError.html) | `500` |
+| `TaskNotFound` | Scheduled task cannot be found (Sync issue) | `500` |
+| `TaskExecutionError` | Failed to execute the given task, an error occured during the task | `500` |
+| `TaskTimeout` | Scheduled task timeout | `500` |
+| `ExternalServiceError` | External service (e.g. another API) returned an error | `500` |

--- a/.docs/error_handling.md
+++ b/.docs/error_handling.md
@@ -37,6 +37,7 @@ The following table shows what kind of errors are currently available on the ser
 | `Conflict` | Requested transaction violates any underlaying constraints that do not fall under `ValidationError`s business logic (e.g. unique constraint in database entry) | `409` |
 | `TooManyRequests` | Limit for requests in a timeframe reached | `429` |
 | 
+| `AuthenticationError` | Indicates that some process during authentication itself failed (e.g. hashing failed because of a invalid salt, JWTService failed to start); Maps: [`argon2::Error`](https://docs.rs/rust-argon2/latest/argon2/enum.Error.html) | `500`
 | `DatabaseConnectionError` | Database connection is either invalid, closed or failed; Wraps: [`diesel::r2d2::PoolError`](https://docs.diesel.rs/master/diesel/r2d2/type.PoolError.html) | `500` |
 | `DatabaseQueryError` | Database query failed to execute; Wraps: [`diesel::result::Error`](https://docs.diesel.rs/2.1.x/diesel/result/enum.Error.html) | `500`
 | `SchedulerError` | Initialization or task scheduling failed; Wraps: [`tokio_cron_scheduler::JobSchedulerError`](https://docs.rs/tokio-cron-scheduler/latest/tokio_cron_scheduler/enum.JobSchedulerError.html) | `500` |

--- a/.docs/error_handling.md
+++ b/.docs/error_handling.md
@@ -44,4 +44,5 @@ The following table shows what kind of errors are currently available on the ser
 | `TaskNotFound` | Scheduled task cannot be found (Sync issue) | `500` |
 | `TaskExecutionError` | Failed to execute the given task, an error occured during the task | `500` |
 | `TaskTimeout` | Scheduled task timeout | `500` |
+| `WebsockertError` | Indicating some occuring error in the websocket communication module (e.g. manager failed to start) | `500` |
 | `ExternalServiceError` | External service (e.g. another API) returned an error | `500` |

--- a/.docs/error_handling.md
+++ b/.docs/error_handling.md
@@ -26,23 +26,23 @@ If the error occurs in a internally server-sided process, the error should be lo
 ### Error Types
 The following table shows what kind of errors are currently available on the server-side:
 
-| Name | Description | Status |
-| ---- | ----------- | ------ |
+| Name | Description | Status | Example encounter |
+| ---- | ----------- | ------ | ----------------- |
 | `BadRequest` | Given input is syntactically incorrect (e.g. results in a malformed JSON, wrong types) | `400` |
-| `ValidationError` | Given input is semantic incorrect and violates business logic (e.g. only positive numbers allowed but got -1 ) | `400` |
-| `Unauthorized` | Authorization failed, API key or token is invalid | `401` |
-| `Forbidden` | Missing permissions after successful authorization | `403` |
+| `ValidationError` | Given input is semantic incorrect and violates business logic (e.g. only positive numbers allowed but got -1 ) | `400` | [JWT generation](../server/src/utils/comm/auth/jwt.rs#L51)
+| `Unauthorized` | Authorization failed, API key or token is invalid | `401` | [Authentication check](../server/src/utils/comm/auth/mod.rs#L62)
+| `Forbidden` | Missing permissions after successful authorization | `403` | [Authentication check](../server/src/utils/comm/auth/mod.rs#L62)
 | `NotFound` | Requested resource not found | `404` |
 | `RequestTimeout` | Response would be sent on an idle / inactive connection | `408` |
 | `Conflict` | Requested transaction violates any underlaying constraints that do not fall under `ValidationError`s business logic (e.g. unique constraint in database entry) | `409` |
 | `TooManyRequests` | Limit for requests in a timeframe reached | `429` |
 | 
-| `AuthenticationError` | Indicates that some process during authentication itself failed (e.g. hashing failed because of a invalid salt, JWTService failed to start); Maps: [`argon2::Error`](https://docs.rs/rust-argon2/latest/argon2/enum.Error.html) | `500`
-| `DatabaseConnectionError` | Database connection is either invalid, closed or failed; Wraps: [`diesel::r2d2::PoolError`](https://docs.diesel.rs/master/diesel/r2d2/type.PoolError.html) | `500` |
-| `DatabaseQueryError` | Database query failed to execute; Wraps: [`diesel::result::Error`](https://docs.diesel.rs/2.1.x/diesel/result/enum.Error.html) | `500`
-| `SchedulerError` | Initialization or task scheduling failed; Wraps: [`tokio_cron_scheduler::JobSchedulerError`](https://docs.rs/tokio-cron-scheduler/latest/tokio_cron_scheduler/enum.JobSchedulerError.html) | `500` |
+| `AuthenticationError` | Indicates that some process during authentication itself failed (e.g. hashing failed because of a invalid salt, JWTService failed to start); Maps: [`argon2::Error`](https://docs.rs/rust-argon2/latest/argon2/enum.Error.html) | `500` | [Hashing of API keys](../server/src/utils/comm/auth/api_key.rs#L73)
+| `DatabaseConnectionError` | Database connection is either invalid, closed or failed; Wraps: [`diesel::r2d2::PoolError`](https://docs.diesel.rs/master/diesel/r2d2/type.PoolError.html) | `500` | [Database Connection](../server/src/db/mod.rs#L47)
+| `DatabaseQueryError` | Database query failed to execute; Wraps: [`diesel::result::Error`](https://docs.diesel.rs/2.1.x/diesel/result/enum.Error.html) | `500` | [Storing API keys in Database](../server/src/utils/comm/auth/models.rs#L80)
+| `SchedulerError` | Initialization or task scheduling failed; Wraps: [`tokio_cron_scheduler::JobSchedulerError`](https://docs.rs/tokio-cron-scheduler/latest/tokio_cron_scheduler/enum.JobSchedulerError.html) | `500` | [Scheduler Start](../server/src/utils/scheduler/mod.rs#L56)
 | `TaskNotFound` | Scheduled task cannot be found (Sync issue) | `500` |
 | `TaskExecutionError` | Failed to execute the given task, an error occured during the task | `500` |
 | `TaskTimeout` | Scheduled task timeout | `500` |
-| `WebsockertError` | Indicating some occuring error in the websocket communication module (e.g. manager failed to start) | `500` |
-| `ExternalServiceError` | External service (e.g. another API) returned an error | `500` |
+| `WebsockertError` | Indicating some occuring error in the websocket communication module (e.g. manager failed to start) | `500` | [Websocket Endpoint](../server/src/utils/comm/websocket/routes.rs#L13)
+| `ExternalServiceError` | External service (e.g. another API) returned an error | `500` | [Database migration at startup](../server/src/db/mod.rs#L52)

--- a/server/src/db/mod.rs
+++ b/server/src/db/mod.rs
@@ -53,7 +53,7 @@ pub fn migrate() -> Result<(), KohakuError> {
     let mut conn = get_connection()?;
     let mig = conn
         .run_pending_migrations(MIGRATIONS)
-        .map_err(|e| KohakuError::InternalServerError(format!("Migration failed: {}", e)))?;
+        .map_err(|e| KohakuError::ExternalServiceError(format!("Migration failed: {}", e)))?;
     info!("Migrations applied! (Count: {})", mig.len());
     Ok(())
 }

--- a/server/src/utils/comm/auth/api_key.rs
+++ b/server/src/utils/comm/auth/api_key.rs
@@ -75,7 +75,7 @@ pub fn hash_key(key: &str) -> Result<String, KohakuError> {
     let argon2 = Argon2::default();
     let hash = argon2
         .hash_password(key.as_bytes(), &salt)
-        .map_err(|e| KohakuError::InternalServerError(e.to_string()))?;
+        .map_err(|e| KohakuError::AuthenticationError(e.to_string()))?;
     Ok(hash.to_string())
 }
 
@@ -101,13 +101,13 @@ pub fn hash_key(key: &str) -> Result<String, KohakuError> {
 /// ```
 pub fn verify_key(key: &str, hash: &str) -> Result<bool, KohakuError> {
     let parsed_hash =
-        PasswordHash::new(hash).map_err(|e| KohakuError::InternalServerError(e.to_string()))?;
+        PasswordHash::new(hash).map_err(|e| KohakuError::AuthenticationError(e.to_string()))?;
     let argon2 = Argon2::default();
 
     match argon2.verify_password(key.as_bytes(), &parsed_hash) {
         Ok(()) => Ok(true),
         Err(argon2::password_hash::Error::Password) => Ok(false),
-        Err(e) => Err(KohakuError::InternalServerError(e.to_string())),
+        Err(e) => Err(KohakuError::ValidationError(e.to_string())),
     }
 }
 

--- a/server/src/utils/comm/auth/jwt.rs
+++ b/server/src/utils/comm/auth/jwt.rs
@@ -91,7 +91,7 @@ impl JWTService {
 
         // Create token
         encode(&Header::default(), &claims, &self.encoding_key)
-            .map_err(|e| KohakuError::InternalServerError(e.to_string()))
+            .map_err(|e| KohakuError::AuthenticationError(e.to_string()))
     }
 
     /// Helper function to generate the bootstrap token. Calls [`JWTService::create_token`].
@@ -233,7 +233,7 @@ impl JWTService {
 pub fn init_jwtservice(encryption_key: &[u8]) -> Result<(), KohakuError> {
     let service = Arc::new(JWTService::new(encryption_key));
     JWT_SERVICE.set(service).map_err(|_| {
-        KohakuError::InternalServerError("JWTService already initialized".to_string())
+        KohakuError::AuthenticationError("JWTService already initialized".to_string())
     })?;
     Ok(())
 }
@@ -247,7 +247,7 @@ pub fn init_jwtservice(encryption_key: &[u8]) -> Result<(), KohakuError> {
 pub fn get_jwtservice() -> Result<Arc<JWTService>, KohakuError> {
     let service = JWT_SERVICE.get();
     if service.is_none() {
-        return Err(KohakuError::InternalServerError(
+        return Err(KohakuError::AuthenticationError(
             "JWTService not initialized - call init_jwtservice first!".to_string(),
         ));
     }

--- a/server/src/utils/comm/auth/mod.rs
+++ b/server/src/utils/comm/auth/mod.rs
@@ -87,7 +87,7 @@ pub async fn check_authorization_token(
             .iter()
             .all(|scope| claims.scopes.contains(&scope.to_string()));
     if !permission {
-        return Err(KohakuError::Unauthorized(
+        return Err(KohakuError::Forbidden(
             "API Key has not the required permissions!".to_string(),
         ));
     }

--- a/server/src/utils/comm/auth/models.rs
+++ b/server/src/utils/comm/auth/models.rs
@@ -101,7 +101,7 @@ pub async fn create_apikey(
     diesel::insert_into(schema::api_keys::table)
         .values(&new_key)
         .get_result(&mut conn)
-        .map_err(KohakuError::DatabaseError)
+        .map_err(KohakuError::DatabaseQueryError)
 }
 
 /// Gets an entry for an identifieable API key in the database
@@ -134,7 +134,9 @@ pub async fn get_apikey(
         query = FilterDsl::filter(query, key_prefix.eq(kp));
     }
 
-    query.load(&mut conn).map_err(KohakuError::DatabaseError)
+    query
+        .load(&mut conn)
+        .map_err(KohakuError::DatabaseQueryError)
 }
 
 /// Removes an entry representing an API key from the database
@@ -168,7 +170,7 @@ pub async fn delete_apikey(
 
     query
         .execute(&mut conn)
-        .map_err(KohakuError::DatabaseError)?;
+        .map_err(KohakuError::DatabaseQueryError)?;
     Ok(())
 }
 

--- a/server/src/utils/comm/auth/routes.rs
+++ b/server/src/utils/comm/auth/routes.rs
@@ -34,7 +34,7 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
 /// - [`Err`] : A [`KohakuError`] based on failed operations. The [`KohakuError`] gets automatically converted to a [`HttpResponse`]
 ///
 /// # Errors
-/// Please see [`KohakuError::details`] for the mapping of [`KohakuError`] to [`actix_web::http::StatusCode`]
+/// Please see [`KohakuError`] for the mapping of [`KohakuError`] to [`actix_web::http::StatusCode`]
 async fn login(req: HttpRequest) -> Result<HttpResponse, KohakuError> {
     let api_key = extract_key(&req);
     if api_key.is_none() {
@@ -69,14 +69,12 @@ async fn login(req: HttpRequest) -> Result<HttpResponse, KohakuError> {
 /// - [`Err`] : A [`KohakuError`] based on failed operations. The [`KohakuError`] gets automatically converted to a [`HttpResponse`]
 ///
 /// # Errors
-/// Please see [`KohakuError::details`] for the mapping of [`KohakuError`] to [`actix_web::http::StatusCode`]
+/// Please see [`KohakuError`] for the mapping of [`KohakuError`] to [`actix_web::http::StatusCode`]
 async fn refresh(req: HttpRequest) -> Result<HttpResponse, KohakuError> {
     let claims = check_authorization_token(&req, None).await?;
     // Check if token is a refresh token
     if claims.token_type != TokenType::Refresh {
-        return Err(KohakuError::ValidationError(
-            "Invalid token type".to_string(),
-        ));
+        return Err(KohakuError::Forbidden("Invalid token type".to_string()));
     }
 
     // Valid, not blacklisted refresh token => Create new access token
@@ -111,7 +109,7 @@ async fn refresh(req: HttpRequest) -> Result<HttpResponse, KohakuError> {
 /// - [`Err`] : A [`KohakuError`] based on failed operations. The [`KohakuError`] gets automatically converted to a [`HttpResponse`]
 ///
 /// # Errors
-/// Please see [`KohakuError::details`] for the mapping of [`KohakuError`] to [`actix_web::http::StatusCode`]
+/// Please see [`KohakuError`] for the mapping of [`KohakuError`] to [`actix_web::http::StatusCode`]
 async fn create(
     req: HttpRequest,
     body: web::Json<CreateKeyRequest>,
@@ -158,7 +156,7 @@ async fn create(
 /// - [`Err`] : A [`KohakuError`] based on failed operations. The [`KohakuError`] gets automatically converted to a [`HttpResponse`]
 ///
 /// # Errors
-/// Please see [`KohakuError::details`] for the mapping of [`KohakuError`] to [`actix_web::http::StatusCode`]
+/// Please see [`KohakuError`] for the mapping of [`KohakuError`] to [`actix_web::http::StatusCode`]
 async fn revoke(
     req: HttpRequest,
     body: web::Json<RevokeKeyRequest>,

--- a/server/src/utils/comm/websocket/manager.rs
+++ b/server/src/utils/comm/websocket/manager.rs
@@ -135,7 +135,7 @@ impl WsConnectionManager {
 
         if let Some(sender) = connections.get(key_id) {
             sender.send(Message::Text(content.into())).map_err(|e| {
-                KohakuError::InternalServerError(format!(
+                KohakuError::WebsocketError(format!(
                     "Failed to send to client with key_id {} : {}",
                     key_id, e
                 ))
@@ -161,9 +161,7 @@ impl WsConnectionManager {
 pub fn init_manager() -> Result<(), KohakuError> {
     let service = Arc::new(WsConnectionManager::new());
     WS_CONNECTION_MANAGER.set(service).map_err(|_| {
-        KohakuError::InternalServerError(
-            "Websocket Connection Manager already initialized".to_string(),
-        )
+        KohakuError::WebsocketError("Websocket Connection Manager already initialized".to_string())
     })?;
     Ok(())
 }
@@ -177,7 +175,7 @@ pub fn init_manager() -> Result<(), KohakuError> {
 pub fn get_manager() -> Result<Arc<WsConnectionManager>, KohakuError> {
     let service = WS_CONNECTION_MANAGER.get();
     if service.is_none() {
-        return Err(KohakuError::InternalServerError(
+        return Err(KohakuError::WebsocketError(
             "Websocket Connection Manager not initialized - call init_manager first!".to_string(),
         ));
     }

--- a/server/src/utils/comm/websocket/routes.rs
+++ b/server/src/utils/comm/websocket/routes.rs
@@ -28,8 +28,8 @@ pub async fn ws_handler(
         key_id: verified_key.id,
     };
 
-    let (response, session, msg_stream) = actix_ws::handle(&req, stream)
-        .map_err(|e| KohakuError::InternalServerError(e.to_string()))?;
+    let (response, session, msg_stream) =
+        actix_ws::handle(&req, stream).map_err(|e| KohakuError::WebsocketError(e.to_string()))?;
 
     let manager = get_manager()?;
     let conn = manager
@@ -42,7 +42,7 @@ pub async fn ws_handler(
         );
         conn_.run(manager);
     } else {
-        return Err(KohakuError::InternalServerError(
+        return Err(KohakuError::WebsocketError(
             "Couldn't create WebSocketConnection!".to_string(),
         ));
     }

--- a/server/src/utils/error.rs
+++ b/server/src/utils/error.rs
@@ -1,16 +1,10 @@
-use actix_web::{error::ResponseError, http::StatusCode, HttpResponse};
+use actix_web::{http::StatusCode, HttpResponse, ResponseError};
 use thiserror::Error;
 
-#[derive(Debug, Error)]
+#[derive(Error, Debug)]
 pub enum KohakuError {
-    #[error("Database error: {0}")]
-    DatabaseError(#[from] diesel::result::Error),
-
-    #[error("Database connection error: {0}")]
-    DatabaseConnectionError(#[from] diesel::r2d2::PoolError),
-
-    #[error("Not found: {0}")]
-    NotFound(String),
+    #[error("Bad request: {0}")]
+    BadRequest(String),
 
     #[error("Validation error: {0}")]
     ValidationError(String),
@@ -18,61 +12,127 @@ pub enum KohakuError {
     #[error("Unauthorized: {0}")]
     Unauthorized(String),
 
+    #[error("Forbidden: {0}")]
+    Forbidden(String),
+
+    #[error("Not found: {0}")]
+    NotFound(String),
+
+    #[error("RequestTimeout: {0}")]
+    RequestTimeout(String),
+
+    #[error("Conflict: {0}")]
+    Conflict(String),
+
+    #[error("Too many requests: {0}")]
+    TooManyRequests(String),
+
+    #[error("Authentication error: {0}")]
+    AuthenticationError(String),
+
+    #[error("Database connection error: {0}")]
+    DatabaseConnectionError(#[from] diesel::r2d2::PoolError),
+
+    #[error("Database query error: {0}")]
+    DatabaseQueryError(#[from] diesel::result::Error),
+
+    #[error("Scheduler error: {0}")]
+    SchedulerError(#[from] tokio_cron_scheduler::JobSchedulerError),
+
+    #[error("Task not found: {0}")]
+    TaskNotFound(String),
+
+    #[error("Task execution error: {0}")]
+    TaskExecutionError(#[from] Box<KohakuError>),
+
+    #[error("Task timeout: {0}")]
+    TaskTimeout(String),
+
+    #[error("Websocket error: {0}")]
+    WebsocketError(String),
+
     #[error("External service error: {0}")]
     ExternalServiceError(String),
-
-    #[error("Internal server error: {0}")]
-    InternalServerError(String),
-
-    #[error("Operation error during {operation}: {source}")]
-    OperationError {
-        operation: String,
-        #[source]
-        source: Box<dyn std::error::Error + Send + Sync>,
-    },
 }
 
 impl KohakuError {
-    fn details(&self) -> (String, StatusCode) {
-        let (message, status) = match self {
-            KohakuError::DatabaseConnectionError(_) => (
-                "Service temporarily unavailable".to_string(),
-                StatusCode::INTERNAL_SERVER_ERROR,
-            ),
-            KohakuError::ExternalServiceError(_) => (
-                "External service error".to_string(),
-                StatusCode::BAD_GATEWAY,
-            ),
-
-            // Propagate message
-            KohakuError::NotFound(msg) => (msg.clone(), StatusCode::NOT_FOUND),
-            KohakuError::ValidationError(msg) => (msg.clone(), StatusCode::BAD_REQUEST),
-            KohakuError::Unauthorized(msg) => (msg.clone(), StatusCode::UNAUTHORIZED),
-
-            // Default
-            _ => (
-                "Internal server error".to_string(),
-                StatusCode::INTERNAL_SERVER_ERROR,
-            ),
+    pub fn error_type(&self) -> String {
+        let s = match self {
+            Self::BadRequest(_) => "BAD_REQUEST",
+            Self::ValidationError(_) => "VALIDATION_ERROR",
+            Self::Unauthorized(_) => "UNAUTHORIZED",
+            Self::Forbidden(_) => "FORBIDDEN",
+            Self::NotFound(_) => "NOT_FOUND",
+            Self::RequestTimeout(_) => "REQUEST_TIMEOUT",
+            Self::Conflict(_) => "CONFLICT",
+            Self::TooManyRequests(_) => "TOO_MANY_REQUESTS",
+            Self::AuthenticationError(_) => "AUTHENTICATION_ERROR",
+            Self::DatabaseConnectionError(_) => "DATABASE_CONNECTION_ERROR",
+            Self::DatabaseQueryError(e) => {
+                let t1 = "DATABASE_QUERY_";
+                let t2 = match e {
+                    diesel::result::Error::DatabaseError(_, _) => "CONFLICT_",
+                    diesel::result::Error::NotFound => "NOT_FOUND_",
+                    _ => "",
+                };
+                let t3 = format!("{t1}{t2}ERROR");
+                &t3.clone()
+            }
+            Self::SchedulerError(_) => "SCHEDULER_ERROR",
+            Self::TaskNotFound(_) => "TASK_NOT_FOUND",
+            Self::TaskExecutionError(_) => "TASK_EXECUTION_ERROR",
+            Self::TaskTimeout(_) => "TASK_TIMEOUT",
+            Self::WebsocketError(_) => "WEBSOCKET_ERROR",
+            Self::ExternalServiceError(_) => "EXTERNAL_SERVICE_ERROR",
+            #[allow(unreachable_patterns)]
+            _ => "UNKNOWN",
         };
-
-        (message, status)
+        s.to_string()
     }
 }
 
 impl ResponseError for KohakuError {
-    fn error_response(&self) -> HttpResponse<actix_web::body::BoxBody> {
-        let (message, status) = self.details();
-
-        HttpResponse::build(status).json(serde_json::json!({
-          "error": message,
-          "status": status.as_u16()
-        }))
+    fn status_code(&self) -> actix_web::http::StatusCode {
+        match self {
+            // 400
+            Self::BadRequest(_) | Self::ValidationError(_) => StatusCode::BAD_REQUEST,
+            // 401
+            Self::Unauthorized(_) => StatusCode::UNAUTHORIZED,
+            // 403
+            Self::Forbidden(_) => StatusCode::FORBIDDEN,
+            // 404
+            Self::NotFound(_) => StatusCode::NOT_FOUND,
+            // 408
+            Self::RequestTimeout(_) => StatusCode::REQUEST_TIMEOUT,
+            // 409
+            Self::Conflict(_) => StatusCode::CONFLICT,
+            // 429
+            Self::TooManyRequests(_) => StatusCode::TOO_MANY_REQUESTS,
+            // 500
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        }
     }
 
-    fn status_code(&self) -> StatusCode {
-        let (_, status) = self.details();
+    fn error_response(&self) -> actix_web::HttpResponse<actix_web::body::BoxBody> {
+        let status = self.status_code();
+        let kind = self.error_type();
+        let message = if status.is_server_error() {
+            // 5XX : Hide implementation details from clients
+            match self {
+                Self::ExternalServiceError(_) => {
+                    "An external service is currently unavailable".to_string()
+                }
+                _ => "An internal error occured. Please try again later.".to_string(),
+            }
+        } else {
+            // 4XX : Expose details as it is the clients fault
+            self.to_string()
+        };
 
-        status
+        HttpResponse::build(status).json(serde_json::json!({
+            "status" : status.as_u16(),
+            "kind" : kind,
+            "message" : message
+        }))
     }
 }

--- a/server/src/utils/tests/mod.rs
+++ b/server/src/utils/tests/mod.rs
@@ -2,4 +2,5 @@
 
 mod test_comm_auth;
 mod test_config;
+mod test_error;
 mod test_scheduler;

--- a/server/src/utils/tests/test_error.rs
+++ b/server/src/utils/tests/test_error.rs
@@ -1,0 +1,122 @@
+use actix_web::{body::to_bytes, http::StatusCode, ResponseError};
+use rstest::rstest;
+use serde::Deserialize;
+
+use crate::utils::error::KohakuError;
+
+// Missing tests for:
+// - KohakuError::DatabaseConnectionError
+// - KohakuError::DatabaseQueryError(diesel::result::Error) if not diesel::result::Error::NotFound
+// Issue: Construction of said error types
+
+#[rstest]
+#[case(KohakuError::BadRequest("".into()), "BAD_REQUEST")]
+#[case(KohakuError::ValidationError("".into()), "VALIDATION_ERROR")]
+#[case(KohakuError::Unauthorized("".into()), "UNAUTHORIZED")]
+#[case(KohakuError::Forbidden("".into()), "FORBIDDEN")]
+#[case(KohakuError::NotFound("".into()), "NOT_FOUND")]
+#[case(KohakuError::RequestTimeout("".into()), "REQUEST_TIMEOUT")]
+#[case(KohakuError::Conflict("".into()), "CONFLICT")]
+#[case(KohakuError::TooManyRequests("".into()), "TOO_MANY_REQUESTS")]
+#[case(KohakuError::AuthenticationError("".into()), "AUTHENTICATION_ERROR")]
+#[case(
+    KohakuError::DatabaseQueryError(diesel::result::Error::NotFound),
+    "DATABASE_QUERY_NOT_FOUND_ERROR"
+)]
+#[case(
+    KohakuError::SchedulerError(tokio_cron_scheduler::JobSchedulerError::CantInit),
+    "SCHEDULER_ERROR"
+)]
+#[case(KohakuError::TaskNotFound("".into()), "TASK_NOT_FOUND")]
+#[case(KohakuError::TaskExecutionError(Box::new(KohakuError::BadRequest("".into()))), "TASK_EXECUTION_ERROR")]
+#[case(KohakuError::TaskTimeout("".into()), "TASK_TIMEOUT")]
+#[case(KohakuError::WebsocketError("".into()), "WEBSOCKET_ERROR")]
+#[case(KohakuError::ExternalServiceError("".into()), "EXTERNAL_SERVICE_ERROR")]
+fn test_kohakuerror_error_type(#[case] error: KohakuError, #[case] expected_kind: &str) {
+    let s = expected_kind.to_string();
+    assert_eq!(error.error_type(), s);
+}
+
+#[rstest]
+#[case(KohakuError::BadRequest("".into()), StatusCode::BAD_REQUEST)]
+#[case(KohakuError::ValidationError("".into()), StatusCode::BAD_REQUEST)]
+#[case(KohakuError::Unauthorized("".into()), StatusCode::UNAUTHORIZED)]
+#[case(KohakuError::Forbidden("".into()), StatusCode::FORBIDDEN)]
+#[case(KohakuError::NotFound("".into()), StatusCode::NOT_FOUND)]
+#[case(KohakuError::RequestTimeout("".into()), StatusCode::REQUEST_TIMEOUT)]
+#[case(KohakuError::Conflict("".into()), StatusCode::CONFLICT)]
+#[case(KohakuError::TooManyRequests("".into()), StatusCode::TOO_MANY_REQUESTS)]
+#[case(KohakuError::AuthenticationError("".into()), StatusCode::INTERNAL_SERVER_ERROR)]
+#[case(
+    KohakuError::DatabaseQueryError(diesel::result::Error::NotFound),
+    StatusCode::INTERNAL_SERVER_ERROR
+)]
+#[case(
+    KohakuError::SchedulerError(tokio_cron_scheduler::JobSchedulerError::CantInit),
+    StatusCode::INTERNAL_SERVER_ERROR
+)]
+#[case(KohakuError::TaskNotFound("".into()), StatusCode::INTERNAL_SERVER_ERROR)]
+#[case(KohakuError::TaskExecutionError(Box::new(KohakuError::BadRequest("".into()))), StatusCode::INTERNAL_SERVER_ERROR)]
+#[case(KohakuError::TaskTimeout("".into()), StatusCode::INTERNAL_SERVER_ERROR)]
+#[case(KohakuError::WebsocketError("".into()), StatusCode::INTERNAL_SERVER_ERROR)]
+#[case(KohakuError::ExternalServiceError("".into()), StatusCode::INTERNAL_SERVER_ERROR)]
+fn test_kohakuerror_status_code(#[case] error: KohakuError, #[case] expected_status: StatusCode) {
+    assert_eq!(error.status_code(), expected_status);
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct ErrorJson {
+    status: u16,
+    kind: String,
+    message: String,
+}
+
+#[tokio::test]
+#[rstest]
+#[case(KohakuError::BadRequest("".into()))]
+#[case(KohakuError::ValidationError("".into()))]
+#[case(KohakuError::Unauthorized("".into()))]
+#[case(KohakuError::Forbidden("".into()))]
+#[case(KohakuError::NotFound("".into()))]
+#[case(KohakuError::RequestTimeout("".into()))]
+#[case(KohakuError::Conflict("".into()))]
+#[case(KohakuError::TooManyRequests("".into()))]
+#[case(KohakuError::AuthenticationError("".into()))]
+#[case(KohakuError::DatabaseQueryError(diesel::result::Error::NotFound))]
+#[case(KohakuError::SchedulerError(tokio_cron_scheduler::JobSchedulerError::CantInit))]
+#[case(KohakuError::TaskNotFound("".into()))]
+#[case(KohakuError::TaskExecutionError(Box::new(KohakuError::BadRequest("".into()))))]
+#[case(KohakuError::TaskTimeout("".into()))]
+#[case(KohakuError::WebsocketError("".into()))]
+#[case(KohakuError::ExternalServiceError("".into()))]
+async fn test_kohakuerror_response(#[case] error: KohakuError) {
+    let status = error.status_code();
+    let kind = error.error_type();
+    let message = if status.is_server_error() {
+        // 5XX : Hide implementation details from clients
+        match error {
+            KohakuError::ExternalServiceError(_) => {
+                "An external service is currently unavailable".to_string()
+            }
+            _ => "An internal error occured. Please try again later.".to_string(),
+        }
+    } else {
+        // 4XX : Expose details as it is the clients fault
+        error.to_string()
+    };
+    let response = error.error_response();
+
+    assert_eq!(response.status(), status);
+
+    let body = to_bytes(response.into_body()).await.unwrap();
+    let json: ErrorJson = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(
+        json,
+        ErrorJson {
+            status: status.as_u16(),
+            kind,
+            message
+        }
+    )
+}


### PR DESCRIPTION
Closes #1 

Refactor error handling to depict more robust and well documented error types.

---

## Further details:
- Documented error handling in `.docs/error_handling.md`
- Reworked KohakuError to mirror documented design changes
- Applied changes to other core features
- Implement Unit Tests

---

## Known Issues:
- Tests do not cover `KohakuError::DatabaseConnectionError` and variants of `KohakuError::DatabaseQueryError` as both error types wrap around database centered error types that are hard to construct and test in a unit test environment. May need to be adapted in integration tests