### PR TITLE
Refactor: Scheduler and tasks

### DIFF
--- a/.docs/error_handling.md
+++ b/.docs/error_handling.md
@@ -41,6 +41,7 @@ The following table shows what kind of errors are currently available on the ser
 | `DatabaseConnectionError` | Database connection is either invalid, closed or failed; Wraps: [`diesel::r2d2::PoolError`](https://docs.diesel.rs/master/diesel/r2d2/type.PoolError.html) | `500` | [Database Connection](../server/src/db/mod.rs#L47)
 | `DatabaseQueryError` | Database query failed to execute; Wraps: [`diesel::result::Error`](https://docs.diesel.rs/2.1.x/diesel/result/enum.Error.html) | `500` | [Storing API keys in Database](../server/src/utils/comm/auth/models.rs#L80)
 | `SchedulerError` | Initialization or task scheduling failed; Wraps: [`tokio_cron_scheduler::JobSchedulerError`](https://docs.rs/tokio-cron-scheduler/latest/tokio_cron_scheduler/enum.JobSchedulerError.html) | `500` | [Scheduler Start](../server/src/utils/scheduler/mod.rs#L56)
+| `TaskBuilderError` | Error occured during the process of building the task | `500` |
 | `TaskNotFound` | Scheduled task cannot be found (Sync issue) | `500` |
 | `TaskExecutionError` | Failed to execute the given task, an error occured during the task | `500` |
 | `TaskTimeout` | Scheduled task timeout | `500` |

--- a/.docs/scheduler.md
+++ b/.docs/scheduler.md
@@ -39,12 +39,12 @@ _(Source: [`tokio_cron_scheduler`](https://github.com/mvniekerk/tokio-cron-sched
 | Field | Required | Description | Method |
 | ----- | -------- | ----------- | ------ |
 | `name` | Yes | Logging purposes | --
-| `cron` | Yes | Schedule in which the task should be executed | [`schedule(cron : &str)`]()
-| `handler` | Yes | Actual function to be executed | [`handler(f : TaskFn)`]()
-| `remaining_runs` | No | How often the task should be executed, if not set default is infinite (indicated by `-1`) | [`run_once()`]() or [`run_times(times: i32)`]()
+| `cron` | Yes | Schedule in which the task should be executed | [`schedule(cron : &str)`](../server/src/utils/scheduler/tasks.rs#L71)
+| `handler` | Yes | Actual function to be executed | [`handler(f : TaskFn)`](../server/src/utils/scheduler/tasks.rs#L89)
+| `remaining_runs` | No | How often the task should be executed, if not set default is infinite (indicated by `-1`) | [`run_once()`](../server/src/utils/scheduler/tasks.rs#L77) or [`run_times(times: i32)`](../server/src/utils/scheduler/tasks.rs#L83)
 
-The construction can be finished via `.build()` at the end and if successful, will return the resulting [`Task`]() struct.
-If the construction fails, a [`KohakuError::TaskBuilderError`]() will be returned.
+The construction can be finished via `.build()` at the end and if successful, will return the resulting [`Task`](../server/src/utils/scheduler/tasks.rs#L18) struct.
+If the construction fails, a `KohakuError::TaskBuilderError` will be returned.
 
 The task can then be scheduled via `scheduler.add_task(task).await`.
 

--- a/.docs/scheduler.md
+++ b/.docs/scheduler.md
@@ -1,0 +1,75 @@
+# Scheduler
+Kohaku features a built-in scheduler using the crate [`tokio_cron_scheduler`](https://github.com/mvniekerk/tokio-cron-scheduler).
+This services allows for automatic processes to spawn at given times and follows a cron-like schedule.
+
+It's available throughout the backend by calling `get_scheduler()` and follows a singleton pattern.
+
+## Cron
+[`tokio_cron_scheduler`](https://github.com/mvniekerk/tokio-cron-scheduler) uses [`croner-rust`](https://github.com/Hexagon/croner-rust) as its cron parser which has the following pattern and available properties
+```
+sec min hour day of month month day of week
+*   *   *    *            *     *
+```
+
+- `*` indicates `ANY`, meaning for example that `0 0 12 * * *` will execute every day exactly one time at `12:00:00` (12 pm)
+- comma-separated values are a list of values, meaning for example that `0 0 12,18 * * *` will execute every day exactly two times, once at `12:00:00` (12 pm) and a second time at `18:00:00` (6 pm)
+- slash-separated values are steps, meaning for example that `*/10 * * * * *` executes every ten seconds
+- `L` indicating the last day of the month
+- `#` indicates the Nth occurence of the weekday
+- `W` closest weekday
+- default pattern is a logical-OR, meaning `0 0 0 1 * MON` would execute every monday and every first day of any month at `00:00:00` (12 am). To have a logical-AND a `+` can extend the functionalities, meaning `0 0 0 1 * +MON` would only execute if the first of any month is also a monday.
+
+
+| Field        | Required | Allowed values  | Allowed special characters | Remarks                                                                                                         |
+| ------------ | -------- | --------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Seconds      | Optional | 0-59            | * , - /                    |                                                                                                                 |
+| Minutes      | Yes      | 0-59            | * , - /                    |                                                                                                                 |
+| Hours        | Yes      | 0-23            | * , - /                    |                                                                                                                 |
+| Day of Month | Yes      | 1-31            | * , - / ? L W              |                                                                                                                 |
+| Month        | Yes      | 1-12 or JAN-DEC | * , - /                    |                                                                                                                 |
+| Day of Week  | Yes      | 0-7 or SUN-MON  | * , - / ? # L +            | 0 to 6 are Sunday to Saturday<br>7 is Sunday, the same as 0<br># is used to specify nth occurrence of a weekday |
+
+For more information: [`croner-rust`](https://github.com/Hexagon/croner-rust)
+
+_(Source: [`tokio_cron_scheduler`](https://github.com/mvniekerk/tokio-cron-scheduler) & [`croner-rust`](https://github.com/Hexagon/croner-rust))_
+
+## Tasks
+[`Tasks`](../server/src/utils/scheduler/tasks.rs) are build via a [`TaskBuilder`](../server/src/utils/scheduler/tasks.rs#L53), allowing for easy construction.
+
+| Field | Required | Description | Method |
+| ----- | -------- | ----------- | ------ |
+| `name` | Yes | Logging purposes | --
+| `cron` | Yes | Schedule in which the task should be executed | [`schedule(cron : &str)`]()
+| `handler` | Yes | Actual function to be executed | [`handler(f : TaskFn)`]()
+| `remaining_runs` | No | How often the task should be executed, if not set default is infinite (indicated by `-1`) | [`run_once()`]() or [`run_times(times: i32)`]()
+
+The construction can be finished via `.build()` at the end and if successful, will return the resulting [`Task`]() struct.
+If the construction fails, a [`KohakuError::TaskBuilderError`]() will be returned.
+
+The task can then be scheduled via `scheduler.add_task(task).await`.
+
+### Examples
+```rust
+// Task will execute once
+let task = Task::builder("test")
+    .schedule("* * * * * *")
+    .run_once()
+    .handler(|| async { Ok(())})
+    .build()?;
+scheduler.add_task(task).await;
+
+// Task will execute every 10 seconds for 5 times
+let task = Task::builder("test")
+  .schedule("*/10 * * * * *")
+  .run_times(5)
+  .handler(|| async { Ok(())})
+  .build()?;
+scheduler.add_task(task).await;
+
+// Task will execute every day at 12:00:00 (12 pm) infinitely
+let task = Task::builder("test")
+  .schedule("0 0 12 * * *")
+  .handler(|| async { Ok(())})
+  .build()?;
+scheduler.add_task(task).await;
+```

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -5,9 +5,9 @@ use tracing_subscriber::FmtSubscriber;
 use crate::{
     db::migrate,
     utils::{
-        comm::{self, auth::jwt::init_jwtservice, websocket::manager::init_manager},
+        comm,
         config::{get_config, init_config},
-        scheduler::{get_scheduler, init_scheduler},
+        initialize_services,
     },
 };
 
@@ -38,30 +38,7 @@ async fn main() -> std::io::Result<()> {
         error!("{}", e);
     }
 
-    // Start scheduler
-    info!("Setting up scheduler ...");
-    if init_scheduler().await.is_err() {
-        error!("Couldn't initialize scheduler!");
-    } else {
-        info!("Scheduler initilialized! Starting scheduler ...");
-        let scheduler = get_scheduler().await;
-        if scheduler.start().await.is_err() {
-            error!("Couldn't start scheduler!");
-        } else {
-            info!("Scheduler started!");
-        }
-    }
-
-    // Start JWT Service
-    info!("Setting up JWTService ...");
-    if init_jwtservice(&config.encryption_key).is_ok() {
-        info!("JWTService started!");
-    } else {
-        error!("Couldn't initialize JWTService! Protected endpoints will return an error!");
-    }
-
-    // Start websocket
-    let _ = init_manager();
+    initialize_services(&config).await;
 
     HttpServer::new(|| {
         App::new()

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -47,8 +47,9 @@ async fn main() -> std::io::Result<()> {
         let scheduler = get_scheduler().await;
         if scheduler.start().await.is_err() {
             error!("Couldn't start scheduler!");
+        } else {
+            info!("Scheduler started!");
         }
-        info!("Scheduler started!");
     }
 
     // Start JWT Service

--- a/server/src/utils/error.rs
+++ b/server/src/utils/error.rs
@@ -39,6 +39,9 @@ pub enum KohakuError {
     #[error("Scheduler error: {0}")]
     SchedulerError(#[from] tokio_cron_scheduler::JobSchedulerError),
 
+    #[error("Task Builder Error: {0}")]
+    TaskBuilderError(String),
+
     #[error("Task not found: {0}")]
     TaskNotFound(String),
 
@@ -79,6 +82,7 @@ impl KohakuError {
                 &t3.clone()
             }
             Self::SchedulerError(_) => "SCHEDULER_ERROR",
+            Self::TaskBuilderError(_) => "TASK_BUILDER_ERROR",
             Self::TaskNotFound(_) => "TASK_NOT_FOUND",
             Self::TaskExecutionError(_) => "TASK_EXECUTION_ERROR",
             Self::TaskTimeout(_) => "TASK_TIMEOUT",

--- a/server/src/utils/mod.rs
+++ b/server/src/utils/mod.rs
@@ -2,8 +2,59 @@
 // TODO: Remove it, when everything is actually used
 #![allow(dead_code)]
 
+use tracing::{error, info};
+
+use crate::utils::{
+    comm::{auth::jwt::init_jwtservice, websocket::manager::init_manager},
+    config::Config,
+    scheduler::{get_scheduler, init_scheduler},
+};
+
 pub mod comm;
 pub mod config;
 pub mod error;
 pub mod scheduler;
 mod tests;
+
+/// Initializes globally accessible services like scheduler, jwtservice and websocket manager.
+///
+/// # Parameters
+/// - `config` : Reference to an active available [`Config`] from the main method.
+pub async fn initialize_services(config: &Config) {
+    if let Err(e) = init_scheduler().await {
+        error!(
+            "Couldn't initialize scheduler! Tasks will not be scheduled! Reason: {}",
+            e
+        );
+    } else {
+        info!("Scheduler initialized! Starting ...");
+        let scheduler = get_scheduler().await;
+        if let Err(er) = scheduler.start().await {
+            error!(
+                "Couldn't start scheduler! Tasks will not be scheduled! Reason: {}",
+                er
+            );
+        } else {
+            info!("Scheduler started!");
+            // TODO: Add default tasks here!
+        }
+    }
+
+    if let Err(e) = init_jwtservice(&config.encryption_key) {
+        error!(
+            "Couldn't initialize JWT service! Protected endpoints locked! Reason: {}",
+            e
+        );
+    } else {
+        info!("JWT Service initialized!");
+    }
+
+    if let Err(e) = init_manager() {
+        error!(
+            "Couldn't initialize websocket manager! Websocket connection deactivated! Reason: {}",
+            e
+        );
+    } else {
+        info!("Websocket Manager initialized!");
+    }
+}

--- a/server/src/utils/scheduler/mod.rs
+++ b/server/src/utils/scheduler/mod.rs
@@ -2,6 +2,7 @@ use std::{error::Error, sync::Arc};
 
 use tokio::sync::{Mutex, OnceCell};
 use tokio_cron_scheduler::{job::job_data::Uuid, Job, JobScheduler, JobSchedulerError};
+use tracing::info;
 
 pub mod tasks;
 use crate::utils::{
@@ -22,10 +23,7 @@ impl Scheduler {
     }
 
     /// Schedule a given task for the scheduler
-    pub async fn add_task<T>(&self, task: T) -> Result<Uuid, KohakuError>
-    where
-        T: Runnable + std::ops::Deref<Target = Task> + 'static + Send + Sync,
-    {
+    pub async fn add_task(&self, task: Task) -> Result<Uuid, KohakuError> {
         let task = Arc::new(task);
         let job = Job::new_async(&task.cron, {
             let task = Arc::clone(&task);
@@ -33,10 +31,19 @@ impl Scheduler {
                 let task = Arc::clone(&task);
                 Box::pin(async move {
                     // Run task
-                    task.run().await;
+                    let res = task.run().await;
 
-                    // Remove task if it should only run once
-                    if task.run_once {
+                    // Remove task if its lifespan is used up
+                    if res.is_err() || task.check_lifespan() {
+                        let reason = if res.is_err() {
+                            "Failure detected"
+                        } else {
+                            "Lifespan depleted"
+                        };
+                        info!(
+                            "[ Scheduler ] Removed task `{}` from schedule. Reason: {}",
+                            task.name, reason
+                        );
                         scheduler.remove(&uuid).await.unwrap();
                     }
                 })

--- a/server/src/utils/scheduler/tasks.rs
+++ b/server/src/utils/scheduler/tasks.rs
@@ -1,66 +1,133 @@
-use std::future::Future;
+use std::{future::Future, pin::Pin, sync::{Arc, atomic::{AtomicI32, Ordering}}};
 
+use tracing::{error, info};
+
+use crate::utils::error::KohakuError;
+
+pub type TaskFn = Arc<dyn Fn() -> Pin<Box<dyn Future<Output = Result<(), KohakuError>> + Send>> + Send + Sync>;
+
+/// Scheduled Task that executes the given function on the given schedule.
 pub struct Task {
-    // Name of task for logging purposes
+    /// Name for logging purposes
     pub name: String,
-    // Schedule (see tokio_cron_scheduler)
+    /// Cron-like schedule (see [`tokio_cron_scheduler`])
     pub cron: String,
-    // How often the task should be repeated. (-1 = Infinite)
-    pub run_once: bool,
+    /// Counter how often this task should be executed until removal (-1 = infinite)
+    pub remaining_runs: Arc<AtomicI32>,
+    /// Actual function to execute on given schedule
+    pub handler: TaskFn
 }
 
 impl Task {
-    pub fn new(name: &str, cron: &str, run_once: bool) -> Self {
-        Self {
-            name: name.to_string(),
-            cron: cron.to_string(),
-            run_once,
+    pub fn builder(name: impl Into<String>) -> TaskBuilder {
+        TaskBuilder::new(name)
+    }
+
+    /// Decrements and checks the current lifespan of the given task.
+    /// 
+    /// # Returns:
+    /// - [`bool`] indicating if the Task should be removed or not. Please note that a set lifespan of `-1` will be counted as `infinite` and will result in no removal.
+    pub fn check_lifespan(&self) -> bool {
+        let current = self.remaining_runs.load(Ordering::SeqCst);
+
+        if current == -1 {
+            return false;
         }
+
+        let new_value = self.remaining_runs.fetch_sub(1, Ordering::SeqCst) - 1;
+        new_value <= 0
+    }
+}
+
+/// Builder for [`Task`].
+pub struct TaskBuilder {
+    name: String,
+    cron: Option<String>,
+    runs: i32,
+    handler: Option<TaskFn>
+}
+
+impl TaskBuilder {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            cron: None,
+            runs: -1,
+            handler: None
+        }
+    }
+
+    /// Sets the schedule using a `cron` structure (see [`tokio_cron_scheduler`])
+    pub fn schedule(mut self, cron: impl Into<String>) -> Self {
+        self.cron = Some(cron.into());
+        self
+    }
+
+    /// Sets the counter to 1 (Default: Infinite)
+    pub fn run_once(mut self) -> Self {
+        self.runs = 1;
+        self
+    }
+
+    /// Sets the counter to `times` (Default: Infinite)
+    pub fn run_times(mut self, times: i32) -> Self {
+        self.runs = times;
+        self
+    }
+
+    /// Setting the function that should be exectued on schedule
+    pub fn handler<F, Fut>(mut self, f: F) -> Self 
+    where 
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<(), KohakuError>> + Send + 'static,
+    {
+        self.handler = Some(Arc::new(move || Box::pin(f())));
+        self
+    }
+
+    /// Builds the given task.
+    /// 
+    /// Requirement are `cron` and `handler`.
+    /// 
+    /// # Returns
+    /// A [`Result`] which is either:
+    /// - [`Ok`] : Constructed [`Task`]
+    /// - [`Err`] : A [`KohakuError::TaskBuilderError`] if either `cron` or `handler` were not set
+    pub fn build(self) -> Result<Task, KohakuError> {
+        let cron = self.cron.ok_or(KohakuError::TaskBuilderError("Schedule (cron) is required".to_string()))?;
+        let handler = self.handler.ok_or(KohakuError::TaskBuilderError("Handler function is required".to_string()))?;
+
+        Ok(Task {
+            name: self.name,
+            cron,
+            remaining_runs: Arc::new(AtomicI32::new(self.runs)),
+            handler
+        })
     }
 }
 
 pub trait Runnable: Send + Sync {
-    fn run(&self) -> impl Future<Output = ()> + Send;
+    fn run(&self) -> impl Future<Output = Result<(), KohakuError>> + Send;
 }
-/// Use this macro to quickly implement the foundation of your task!
-///
-/// Example:
-/// ```
-///   pub struct MyTask(Task);
-///
-///   impl MyTask {
-///     pub fn new() -> Self {
-///        Self(Task::new("Example", "0,30 * * * * *", false))
-///     }
-///     async fn execute(&self) -> Result<(), String> {
-///         info!("Example-Task-Execution");
-///         Ok(())
-///     }
-///   }
-///   impl_task_wrapper!(MyTask);
-/// ```
-///
-#[macro_export]
-macro_rules! impl_task_wrapper {
-    ($($t:ty),*) => {
-        $(
-            impl std::ops::Deref for $t {
-                type Target = Task;
 
-                fn deref(&self) -> &Self::Target {
-                    &self.0
-                }
+impl Runnable for Task {
+    /// Runs the scheduled tasks function.
+    /// Result will be logged using [`tracing`] on the server side.
+    /// 
+    /// # Returns
+    /// A [`Result`] which is either:
+    /// - [`Ok`] : Task executed without any errors
+    /// - [`Err`] : A [`KohakuError::TaskExecutionError`] holding the error type which lead to a failure
+    async fn run(&self) -> Result<(), KohakuError> {
+        match (self.handler)().await {
+            Ok(_) => {
+                info!("[ Task - {} ] Execution finished!", self.name);
+                Ok(())
+            },
+            Err(e) => {
+                error!("[ Task - {} ] Failure detected: {}", self.name, e);
+                Err(KohakuError::TaskExecutionError(Box::new(e)))
             }
-
-            impl $crate::utils::scheduler::tasks::Runnable for $t {
-              async fn run(&self) -> () {
-                if let Err(e) = self.execute().await {
-                  tracing::error!("[ Task - {} ] - Failure detected: {}", self.0.name, e);
-                  return;
-                }
-                tracing::info!("[ Task - {} ] - Done!", self.0.name);
-              }
-            }
-        )*
+        }
     }
 }

--- a/server/src/utils/scheduler/tasks.rs
+++ b/server/src/utils/scheduler/tasks.rs
@@ -1,10 +1,18 @@
-use std::{future::Future, pin::Pin, sync::{Arc, atomic::{AtomicI32, Ordering}}};
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicI32, Ordering},
+        Arc,
+    },
+};
 
 use tracing::{error, info};
 
 use crate::utils::error::KohakuError;
 
-pub type TaskFn = Arc<dyn Fn() -> Pin<Box<dyn Future<Output = Result<(), KohakuError>> + Send>> + Send + Sync>;
+pub type TaskFn =
+    Arc<dyn Fn() -> Pin<Box<dyn Future<Output = Result<(), KohakuError>> + Send>> + Send + Sync>;
 
 /// Scheduled Task that executes the given function on the given schedule.
 pub struct Task {
@@ -15,7 +23,7 @@ pub struct Task {
     /// Counter how often this task should be executed until removal (-1 = infinite)
     pub remaining_runs: Arc<AtomicI32>,
     /// Actual function to execute on given schedule
-    pub handler: TaskFn
+    pub handler: TaskFn,
 }
 
 impl Task {
@@ -24,7 +32,7 @@ impl Task {
     }
 
     /// Decrements and checks the current lifespan of the given task.
-    /// 
+    ///
     /// # Returns:
     /// - [`bool`] indicating if the Task should be removed or not. Please note that a set lifespan of `-1` will be counted as `infinite` and will result in no removal.
     pub fn check_lifespan(&self) -> bool {
@@ -44,7 +52,7 @@ pub struct TaskBuilder {
     name: String,
     cron: Option<String>,
     runs: i32,
-    handler: Option<TaskFn>
+    handler: Option<TaskFn>,
 }
 
 impl TaskBuilder {
@@ -53,7 +61,7 @@ impl TaskBuilder {
             name: name.into(),
             cron: None,
             runs: -1,
-            handler: None
+            handler: None,
         }
     }
 
@@ -76,8 +84,8 @@ impl TaskBuilder {
     }
 
     /// Setting the function that should be exectued on schedule
-    pub fn handler<F, Fut>(mut self, f: F) -> Self 
-    where 
+    pub fn handler<F, Fut>(mut self, f: F) -> Self
+    where
         F: Fn() -> Fut + Send + Sync + 'static,
         Fut: Future<Output = Result<(), KohakuError>> + Send + 'static,
     {
@@ -86,22 +94,26 @@ impl TaskBuilder {
     }
 
     /// Builds the given task.
-    /// 
+    ///
     /// Requirement are `cron` and `handler`.
-    /// 
+    ///
     /// # Returns
     /// A [`Result`] which is either:
     /// - [`Ok`] : Constructed [`Task`]
     /// - [`Err`] : A [`KohakuError::TaskBuilderError`] if either `cron` or `handler` were not set
     pub fn build(self) -> Result<Task, KohakuError> {
-        let cron = self.cron.ok_or(KohakuError::TaskBuilderError("Schedule (cron) is required".to_string()))?;
-        let handler = self.handler.ok_or(KohakuError::TaskBuilderError("Handler function is required".to_string()))?;
+        let cron = self.cron.ok_or(KohakuError::TaskBuilderError(
+            "Schedule (cron) is required".to_string(),
+        ))?;
+        let handler = self.handler.ok_or(KohakuError::TaskBuilderError(
+            "Handler function is required".to_string(),
+        ))?;
 
         Ok(Task {
             name: self.name,
             cron,
             remaining_runs: Arc::new(AtomicI32::new(self.runs)),
-            handler
+            handler,
         })
     }
 }
@@ -113,7 +125,7 @@ pub trait Runnable: Send + Sync {
 impl Runnable for Task {
     /// Runs the scheduled tasks function.
     /// Result will be logged using [`tracing`] on the server side.
-    /// 
+    ///
     /// # Returns
     /// A [`Result`] which is either:
     /// - [`Ok`] : Task executed without any errors
@@ -123,7 +135,7 @@ impl Runnable for Task {
             Ok(_) => {
                 info!("[ Task - {} ] Execution finished!", self.name);
                 Ok(())
-            },
+            }
             Err(e) => {
                 error!("[ Task - {} ] Failure detected: {}", self.name, e);
                 Err(KohakuError::TaskExecutionError(Box::new(e)))

--- a/server/src/utils/scheduler/tasks.rs
+++ b/server/src/utils/scheduler/tasks.rs
@@ -40,6 +40,8 @@ impl Task {
 
         if current == -1 {
             return false;
+        } else if current == 0 {
+            return true;
         }
 
         let new_value = self.remaining_runs.fetch_sub(1, Ordering::SeqCst) - 1;

--- a/server/src/utils/tests/test_error.rs
+++ b/server/src/utils/tests/test_error.rs
@@ -27,6 +27,7 @@ use crate::utils::error::KohakuError;
     KohakuError::SchedulerError(tokio_cron_scheduler::JobSchedulerError::CantInit),
     "SCHEDULER_ERROR"
 )]
+#[case(KohakuError::TaskBuilderError("".into()), "TASK_BUILDER_ERROR")]
 #[case(KohakuError::TaskNotFound("".into()), "TASK_NOT_FOUND")]
 #[case(KohakuError::TaskExecutionError(Box::new(KohakuError::BadRequest("".into()))), "TASK_EXECUTION_ERROR")]
 #[case(KohakuError::TaskTimeout("".into()), "TASK_TIMEOUT")]
@@ -55,6 +56,7 @@ fn test_kohakuerror_error_type(#[case] error: KohakuError, #[case] expected_kind
     KohakuError::SchedulerError(tokio_cron_scheduler::JobSchedulerError::CantInit),
     StatusCode::INTERNAL_SERVER_ERROR
 )]
+#[case(KohakuError::TaskBuilderError("".into()), StatusCode::INTERNAL_SERVER_ERROR)]
 #[case(KohakuError::TaskNotFound("".into()), StatusCode::INTERNAL_SERVER_ERROR)]
 #[case(KohakuError::TaskExecutionError(Box::new(KohakuError::BadRequest("".into()))), StatusCode::INTERNAL_SERVER_ERROR)]
 #[case(KohakuError::TaskTimeout("".into()), StatusCode::INTERNAL_SERVER_ERROR)]
@@ -84,6 +86,7 @@ struct ErrorJson {
 #[case(KohakuError::AuthenticationError("".into()))]
 #[case(KohakuError::DatabaseQueryError(diesel::result::Error::NotFound))]
 #[case(KohakuError::SchedulerError(tokio_cron_scheduler::JobSchedulerError::CantInit))]
+#[case(KohakuError::TaskBuilderError("".into()))]
 #[case(KohakuError::TaskNotFound("".into()))]
 #[case(KohakuError::TaskExecutionError(Box::new(KohakuError::BadRequest("".into()))))]
 #[case(KohakuError::TaskTimeout("".into()))]

--- a/server/src/utils/tests/test_scheduler.rs
+++ b/server/src/utils/tests/test_scheduler.rs
@@ -188,8 +188,7 @@ async fn test_scheduler_task_run_once() {
 #[tokio::test]
 #[rstest]
 #[case(2)]
-#[case(5)]
-#[case(10)]
+#[case(3)]
 async fn test_scheduler_task_run_times(#[case] amount: i32) {
     let _ = init_scheduler().await;
     let scheduler = get_scheduler().await;
@@ -198,7 +197,7 @@ async fn test_scheduler_task_run_times(#[case] amount: i32) {
     let counter = Arc::new(AtomicI32::new(0));
     let counter_clone = counter.clone();
     let task = Task::builder("test")
-        .schedule("*/1 * * * * *")
+        .schedule("* * * * * *")
         .run_times(amount)
         .handler(move || {
             let count = counter_clone.clone();
@@ -215,17 +214,18 @@ async fn test_scheduler_task_run_times(#[case] amount: i32) {
     let res = scheduler.add_task(task).await;
     assert!(res.is_ok());
 
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    let waittime = (amount as u64) + 3;
+    tokio::time::sleep(Duration::from_secs(waittime)).await;
 
     let c = counter.load(Ordering::SeqCst);
+    let diff = amount - c;
 
-    if amount <= 3 {
-        // Can be executed in time frame
-        assert_eq!(c, amount);
-        assert_eq!(rem_runs.load(Ordering::SeqCst), 0);
-    } else {
-        // Cannot be executed in time frame
-        // As the scheduler could take a sec to init the task we allow a one sec / one run error window
-        assert!(2 <= c && c <= 3);
-    }
+    // Allow for an error range of 1 count based on scheduler startup and schedule time based on system
+    assert!(
+        diff <= 1,
+        "Expected {} executions, got {} (Diff Threshold : 1)",
+        amount,
+        c
+    );
+    assert_eq!(rem_runs.load(Ordering::SeqCst), 0);
 }

--- a/server/src/utils/tests/test_scheduler.rs
+++ b/server/src/utils/tests/test_scheduler.rs
@@ -227,5 +227,5 @@ async fn test_scheduler_task_run_times(#[case] amount: i32) {
         amount,
         c
     );
-    assert_eq!(rem_runs.load(Ordering::SeqCst), 0);
+    assert_eq!(rem_runs.load(Ordering::SeqCst), diff);
 }

--- a/server/src/utils/tests/test_scheduler.rs
+++ b/server/src/utils/tests/test_scheduler.rs
@@ -1,111 +1,231 @@
 use std::{
     sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc, Mutex,
+        atomic::{AtomicI32, AtomicU32, Ordering},
+        Arc,
     },
     time::Duration,
 };
 
-use serial_test::serial;
+use rstest::rstest;
 
-use crate::{
-    impl_task_wrapper,
-    utils::scheduler::{get_scheduler, init_scheduler, tasks::Task, Scheduler},
+use crate::utils::{
+    error::KohakuError,
+    scheduler::{
+        get_scheduler, init_scheduler,
+        tasks::{Runnable, Task},
+    },
 };
 
-#[tokio::test]
-#[should_panic]
-async fn test_scheduler_not_initialized_before_get() {
-    let _ = get_scheduler().await;
+#[test]
+fn test_task_builder_basic() {
+    let name = "test";
+    let cron = "* * * * * *";
+
+    let task = Task::builder(name)
+        .schedule(cron)
+        .handler(|| async { Ok(()) })
+        .build();
+
+    assert!(task.is_ok());
+    let task = task.unwrap();
+    assert_eq!(task.name, name);
+    assert_eq!(task.cron, cron);
+    assert_eq!(task.remaining_runs.load(Ordering::SeqCst), -1);
 }
 
-#[tokio::test]
-async fn test_scheduler_singleton() {
-    // #1 Test that first initialization succeeds and second fails
-    assert!(init_scheduler().await.is_ok());
-    assert!(init_scheduler().await.is_err());
+#[rstest]
+#[case(1)]
+#[case(10)]
+fn test_task_builder_diff_runs(#[case] amount: i32) {
+    let tb = Task::builder("test")
+        .schedule("*/1 * * * * *")
+        .handler(|| async { Ok(()) });
 
-    // #2 Test if getter returns same instance
-    let s1 = get_scheduler().await;
-    let s2 = get_scheduler().await;
-    assert!(Arc::ptr_eq(&s1, &s2))
-}
-
-// ------------------------------------------------------------------------
-
-static COUNTER: Mutex<Option<Arc<AtomicUsize>>> = Mutex::new(None);
-
-struct TestTask(Task);
-
-impl TestTask {
-    pub fn new(run_once: bool) -> Self {
-        Self(Task::new("TestTask", "*/1 * * * * *", run_once))
+    let task: Result<Task, KohakuError>;
+    if amount == 1 {
+        task = tb.run_once().build();
+    } else {
+        task = tb.run_times(amount).build();
     }
 
-    async fn execute(&self) -> Result<(), String> {
-        let counter = COUNTER.lock().unwrap();
-        let counter = counter.as_ref().expect("Counter not initialized");
-        counter.fetch_add(1, Ordering::SeqCst);
-        Ok(())
-    }
+    assert!(task.is_ok());
+    let task = task.unwrap();
+    assert_eq!(task.remaining_runs.load(Ordering::SeqCst), amount);
 }
 
-impl_task_wrapper!(TestTask);
-
-#[tokio::test]
-async fn test_add_task() {
-    let task1 = TestTask::new(true);
-    let task2 = TestTask::new(true);
-
-    let scheduler = Scheduler::new().await.unwrap();
-    // #1 Test if task is added if scheduler has not started yet
-    assert!(scheduler.add_task(task1).await.is_ok());
-    let _ = scheduler.start().await;
-
-    // #2 Test if task is added if scheduler has already started
-    assert!(scheduler.add_task(task2).await.is_ok());
-}
-
-#[tokio::test]
-#[serial]
-async fn test_execute_task_once() {
-    let counter = Arc::new(AtomicUsize::new(0));
-    *COUNTER.lock().unwrap() = Some(counter.clone());
-
-    let task = TestTask::new(true);
-
-    let scheduler = Scheduler::new().await.unwrap();
-    let _ = scheduler.add_task(task).await;
-    let _ = scheduler.start().await;
-
-    tokio::time::sleep(Duration::from_secs(3)).await;
-
-    let count = counter.load(Ordering::SeqCst);
-    assert_eq!(
-        count, 1,
-        "Task should run exactly once, but ran {} times",
-        count
-    );
-}
-
-#[tokio::test]
-#[serial]
-async fn test_execute_task_multiple_times() {
-    let counter = Arc::new(AtomicUsize::new(0));
-    *COUNTER.lock().unwrap() = Some(counter.clone());
-
-    let task = TestTask::new(false);
-
-    let scheduler = Scheduler::new().await.unwrap();
-    let _ = scheduler.add_task(task).await;
-    let _ = scheduler.start().await;
-
-    tokio::time::sleep(Duration::from_secs(3)).await;
-
-    let count = counter.load(Ordering::SeqCst);
+#[test]
+fn test_task_builder_missing_schedule() {
+    let task = Task::builder("test").handler(|| async { Ok(()) }).build();
+    assert!(task.is_err());
     assert!(
-        count > 1,
-        "Task should run multiple times, but ran {} time(s)",
-        count
+        matches!(task, Err(KohakuError::TaskBuilderError(t)) if t == "Schedule (cron) is required".to_string())
     );
+}
+
+#[test]
+fn test_task_builder_missing_handler() {
+    let task = Task::builder("test").schedule("* * * * * *").build();
+    assert!(task.is_err());
+    assert!(
+        matches!(task, Err(KohakuError::TaskBuilderError(t)) if t == "Handler function is required".to_string())
+    );
+}
+
+#[tokio::test]
+async fn test_task_decrement_count_infinite() {
+    let task = Task::builder("test")
+        .schedule("*/1 * * * * *")
+        .handler(|| async { Ok(()) })
+        .build();
+    assert!(task.is_ok());
+    let task = task.unwrap();
+
+    assert_eq!(task.remaining_runs.load(Ordering::SeqCst), -1);
+    assert!(!task.check_lifespan());
+    assert_eq!(task.remaining_runs.load(Ordering::SeqCst), -1);
+}
+
+#[tokio::test]
+async fn test_task_decrement_count_once() {
+    let task = Task::builder("test")
+        .schedule("*/1 * * * * *")
+        .handler(|| async { Ok(()) })
+        .run_once()
+        .build();
+    assert!(task.is_ok());
+    let task = task.unwrap();
+
+    assert_eq!(task.remaining_runs.load(Ordering::SeqCst), 1);
+    assert!(task.check_lifespan());
+    assert_eq!(task.remaining_runs.load(Ordering::SeqCst), 0);
+    assert!(task.check_lifespan());
+    assert_eq!(task.remaining_runs.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+#[rstest]
+#[case(2)]
+#[case(5)]
+#[case(10)]
+async fn test_task_decrement_count_finite_times(#[case] amount: i32) {
+    let task = Task::builder("test")
+        .schedule("*/1 * * * * *")
+        .handler(|| async { Ok(()) })
+        .run_times(amount)
+        .build();
+    assert!(task.is_ok());
+    let task = task.unwrap();
+
+    assert_eq!(task.remaining_runs.load(Ordering::SeqCst), amount);
+    assert!(!task.check_lifespan());
+    assert_eq!(task.remaining_runs.load(Ordering::SeqCst), amount - 1);
+
+    if amount == 2 {
+        assert!(task.check_lifespan());
+    } else {
+        assert!(!task.check_lifespan());
+    }
+    assert_eq!(task.remaining_runs.load(Ordering::SeqCst), amount - 2);
+}
+
+#[tokio::test]
+async fn test_task_execution() {
+    let counter = Arc::new(AtomicU32::new(0));
+    let counter_clone = counter.clone();
+    let task = Task::builder("test")
+        .schedule("*/1 * * * * *")
+        .run_once()
+        .handler(move || {
+            let count = counter_clone.clone();
+            async move {
+                count.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        })
+        .build();
+
+    assert!(task.is_ok());
+    let task = task.unwrap();
+
+    let res = task.run().await;
+    assert!(res.is_ok());
+
+    let c = counter.load(Ordering::SeqCst);
+    assert_eq!(c, 1);
+}
+
+#[tokio::test]
+async fn test_scheduler_task_run_once() {
+    let _ = init_scheduler().await;
+    let scheduler = get_scheduler().await;
+    let _ = scheduler.start().await;
+
+    let counter = Arc::new(AtomicU32::new(0));
+    let counter_clone = counter.clone();
+    let task = Task::builder("test")
+        .schedule("*/1 * * * * *")
+        .run_once()
+        .handler(move || {
+            let count = counter_clone.clone();
+            async move {
+                count.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        })
+        .build();
+
+    assert!(task.is_ok());
+    let task = task.unwrap();
+    let res = scheduler.add_task(task).await;
+    assert!(res.is_ok());
+
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    let c = counter.load(Ordering::SeqCst);
+    assert_eq!(c, 1);
+}
+
+#[tokio::test]
+#[rstest]
+#[case(2)]
+#[case(5)]
+#[case(10)]
+async fn test_scheduler_task_run_times(#[case] amount: i32) {
+    let _ = init_scheduler().await;
+    let scheduler = get_scheduler().await;
+    let _ = scheduler.start().await;
+
+    let counter = Arc::new(AtomicI32::new(0));
+    let counter_clone = counter.clone();
+    let task = Task::builder("test")
+        .schedule("*/1 * * * * *")
+        .run_times(amount)
+        .handler(move || {
+            let count = counter_clone.clone();
+            async move {
+                count.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        })
+        .build();
+
+    assert!(task.is_ok());
+    let task = task.unwrap();
+    let rem_runs = task.remaining_runs.clone();
+    let res = scheduler.add_task(task).await;
+    assert!(res.is_ok());
+
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    let c = counter.load(Ordering::SeqCst);
+
+    if amount <= 3 {
+        // Can be executed in time frame
+        assert_eq!(c, amount);
+        assert_eq!(rem_runs.load(Ordering::SeqCst), 0);
+    } else {
+        // Cannot be executed in time frame
+        // As the scheduler could take a sec to init the task we allow a one sec / one run error window
+        assert!(2 <= c && c <= 3);
+    }
 }


### PR DESCRIPTION
closes #8 

Reworked scheduler and tasks to feature a builder pattern for tasks as well as update tests and documentation.
Additionally services now get initialized in `utils/mod.rs` instead of in `main.rs`.